### PR TITLE
Use modern libcamera deps and new python-chi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,49 +1,15 @@
-# Use a base Debian Bullseye image
-FROM debian:bullseye
+FROM debian:bookworm-20250630-slim AS base
 
-# Install necessary dependencies and tools
-RUN apt-get update && \
-    apt-get install -y \
-    dkms \
-    build-essential \
-    git \
-    v4l-utils \
-    python3-dev \
-    python3-pip \
-    python3-yaml \
-    python3-ply \
-    cmake \
-    libboost-dev \
-    libgnutls28-dev openssl libtiff5-dev libjpeg-dev libpng-dev pybind11-dev \
-    qtbase5-dev libqt5core5a libqt5gui5 libqt5widgets5 \
-    libboost-program-options-dev libdrm-dev libexif-dev \
-    && apt-get clean
+RUN apt-get update && apt-get install -y --no-install-recommends gnupg
+RUN echo "deb http://archive.raspberrypi.org/debian/ bookworm main" > /etc/apt/sources.list.d/raspi.list \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 82B129927FA3303E
 
-# Install the required Python modules using pip
-RUN pip3 install meson ninja jinja2 
-#ply pyyaml
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    python3-libcamera \
+    python3-picamera2 \
+    libcamera-apps-lite
 
-# Clone and build libcamera
-RUN git clone https://github.com/raspberrypi/libcamera.git /libcamera && \
-    cd /libcamera && \
-    meson setup build --buildtype=release -Dpipelines=rpi/vc4,rpi/pisp -Dipas=rpi/vc4,rpi/pisp -Dv4l2=true -Dgstreamer=disabled -Dtest=false -Dlc-compliance=disabled -Dcam=disabled -Dqcam=disabled -Ddocumentation=disabled -Dpycamera=enabled && \
-    ninja -C build && \
-    ninja -C build install
-
-# Clone and build rpicam-apps
-RUN git clone https://github.com/raspberrypi/rpicam-apps.git /rpicam-apps && \
-    cd /rpicam-apps && \
-    sed -i 's/platform = options_->GetPlatform();/platform = Platform::VC4;/' core/rpicam_app.cpp && \
-    meson setup build -Denable_libav=disabled -Denable_drm=enabled -Denable_egl=disabled -Denable_qt=disabled -Denable_opencv=disabled -Denable_tflite=disabled && \
-    meson compile -C build && \
-    meson install -C build
-
-RUN usermod -a -G video root
-
-# Ensure the container has access to video devices
-ENV UDEV=on
-ENV LD_LIBRARY_PATH=/usr/local/lib/aarch64-linux-gnu:/libcamera/build/src/libcamera:${LD_LIBRARY_PATH}
-
-WORKDIR /usr/src/app
+WORKDIR /app
 
 CMD ["sleep", "infinity"]

--- a/camera_test.py
+++ b/camera_test.py
@@ -1,0 +1,13 @@
+import time
+
+from picamera2 import Picamera2
+
+picam2 = Picamera2()
+
+picam2.start()
+time.sleep(2)
+
+metadata = picam2.capture_file("/app/test2.jpg")
+print(metadata)
+
+picam2.close()

--- a/camera_test.py
+++ b/camera_test.py
@@ -4,10 +4,13 @@ from picamera2 import Picamera2
 
 picam2 = Picamera2()
 
+camera_config = picam2.create_still_configuration(main={"size": (1920, 1080)})
+picam2.configure(camera_config)
+
 picam2.start()
 time.sleep(2)
 
-metadata = picam2.capture_file("/app/test2.jpg")
+metadata = picam2.capture_file("/app/test2.png")
 print(metadata)
 
 picam2.close()

--- a/picamera_tutorial.ipynb
+++ b/picamera_tutorial.ipynb
@@ -7,9 +7,9 @@
    "source": [
     "# Peripheral showcase: Pi Camera Module 3 in CHI@Edge\n",
     "\n",
-    "Welcome to this Jupyter notebook guide on using the Raspberry Pi Camera Module 3 within CHI@Edge. This artifact will walk you through the steps to access and utilize the camera for your edge computing experiments.. \n",
+    "Welcome to this Jupyter notebook guide on using the Camera on Raspberry Pis in CHI@Edge. This artifact will walk you through the steps to access and utilize the camera for your edge computing experiments.\n",
     "\n",
-    "**Important Note:** There is only one device with the camera attached at the moment. We currently are in the process of staffing several of our raspberrypi 4 devices with pi camera modules; later, this month of June 2024, an official blogpost on peripherals will accompany this artifact presenting a hollistic approach for users to add peripherals to CHI@Edge.\n",
+    "**Important Note:** This notebook will work with any camera module, but only for devices that are set up to use the \"libcamera\" drivers. As of July 2025, all devices in CHI@Edge are configured this way.\n",
     "\n",
     "In the following example we'll show how to use the Pi Camera Module 3 on a Raspberry Pi 4 to capture both a png image and an h264 30 fps video. "
    ]
@@ -21,29 +21,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import chi\n",
-    "chi.use_site(\"CHI@Edge\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "20761240-ed5c-4ec8-8d51-33cf950f28e7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "chi.set(\"project_name\", \"your_project_name_goes_here\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "84038b03-90e9-4f24-898e-d75c9199f8fc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from chi import container\n",
-    "from chi import lease"
+    "from chi import context\n",
+    "\n",
+    "context.choose_site(default=\"CHI@Edge\")\n",
+    "context.choose_project()"
    ]
   },
   {
@@ -53,7 +34,7 @@
    "source": [
     "## Creating the Lease\n",
     "\n",
-    "To access the camera, we need to make a lease for the specific device that the camera is currently attached to. The device ```sj-rpi4-02``` is specifically set up with the proper kernel and driver options to enable support for the Pi Camera module 3."
+    "To access the camera, we need to make a lease for the specific device that the camera is currently attached to. As of July 2025, we're still implementing the autodetection of this, but the below devices will have it attached."
    ]
   },
   {
@@ -63,31 +44,38 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
+    "from chi import hardware\n",
     "\n",
-    "# get your username, just used to name leases something identifiable\n",
-    "username = os.environ.get(\"USER\")\n",
+    "device_type = \"raspberrypi4-64\"\n",
+    "available_devices = hardware.get_devices(filter_reserved=True, device_type=device_type)\n",
     "\n",
-    "# machine name refers to the \"type\" of device\n",
-    "machine_name = \"raspberrypi4-64\"\n",
+    "picamera_devs = [d for d in available_devices if d.device_name.startswith(\"iot-rpi4-picam\")]\n",
+    "display([d.device_name for d in picamera_devs])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa8de1e0",
+   "metadata": {},
+   "source": [
+    "And then make a lease for one of them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3adb24c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from chi import lease\n",
+    "from datetime import timedelta\n",
     "\n",
-    "# Reserving the specific device to which the Pi Camera Module 3 is attached\n",
-    "device_name = \"sj-rpi4-02\"\n",
+    "my_lease = lease.Lease(\"rpi4-camera-lease\", duration=timedelta(hours=3))\n",
     "\n",
-    "# get dates for lease start and end\n",
-    "start, end = lease.lease_duration(days=1)\n",
-    "\n",
-    "# make a unique name for the lease\n",
-    "lease_name = f\"{username}-{machine_name}-{start}\"\n",
-    "\n",
-    "reservations = []\n",
-    "lease.add_device_reservation(reservations, count=1, machine_name=machine_name, device_name=device_name)\n",
-    "container_lease = lease.create_lease(lease_name, reservations, start, end)\n",
-    "lease_id = container_lease[\"id\"]\n",
-    "\n",
-    "print(f\"created lease with name {lease_name} and uuid {lease_id}, waiting for it to start. This can take up to 60s.\")\n",
-    "lease.wait_for_active(lease_id)\n",
-    "print(\"Done!\")"
+    "my_lease.add_device_reservation(picamera_devs[0])\n",
+    "# my_lease.add_device_reservation(device_name='iot-rpi4-picam2',amount=1) # or a specific one!\n",
+    "my_lease.submit(idempotent=True)"
    ]
   },
   {
@@ -99,11 +87,13 @@
     "\n",
     "To take pictures and videos with the camera, we need to launch a container image with all the following pre-requisites:\n",
     "\n",
-    "- pi_camera device profile: a flag to expose all the necessary /dev devices required for the camera support\n",
+    "- pi_libcamera device profile: a flag to expose all the necessary /dev devices required for the camera support\n",
     "- libcamera: A complex camera stack designed to support all kinds of cameras on Linux.\n",
     "- rpicam-apps: A set of example applications demonstrating how to use libcamera on Raspberry Pi.\n",
     "\n",
-    "We compile slightly modified custom versions of both dependencies and package them in our docker image ```ghcr.io/chameleoncloud/edge-picamera-image:latest```. This is currently the only verified image working on CHI@Edge, we provide the [Dockerfile](https://github.com/ChameleonCloud/edge-picamera-image/blob/ea0b0c48fa79c438bf28281bceddd5620fee26ac/Dockerfile) for reproducibility and customization."
+    "We provide a prebuilt container image with these dependencies: ```ghcr.io/chameleoncloud/edge-picamera-image:latest```. For reprodcibility and customization, the Dockerfile for the image can be found in the same repo as this notebook.\n",
+    "\n",
+    "Below, we will launch a long-running container doing more or less \"nothing\" so that it stays running, and then execute commands interactively."
    ]
   },
   {
@@ -113,25 +103,42 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"Requesting container ... This may take a while as the large (>1GB) container image is being downloaded\")\n",
+    "from chi import container\n",
     "\n",
-    "# Set a name for the container. Because CHI@Edge uses Kubernetes, ensure that underscores aren't in the name\n",
-    "container_name = f\"tutorial-{machine_name}-picamera\".replace(\"_\",\"-\")\n",
+    "my_container = container.Container(\n",
+    "    \"rpi4-camera-test-01\",\n",
+    "    image_ref=\"shermanm/picamera:latest\",\n",
+    "    exposed_ports=[],\n",
+    "    reservation_id=my_lease.device_reservations[0][\"id\"],\n",
+    "    command=[\"sleep\", \"3600\"],\n",
+    "    device_profiles=[\"pi_libcamera\"],\n",
+    ")\n",
+    "my_container.submit()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ceda18d",
+   "metadata": {},
+   "source": [
+    "## Verifying that the camera and drivers work\n",
     "\n",
-    "try:\n",
-    "    my_container = container.create_container(\n",
-    "        container_name,\n",
-    "        image=\"ghcr.io/chameleoncloud/edge-picamera-image:latest\",\n",
-    "        workdir=\"/home\",\n",
-    "        device_profiles=[\"pi_camera\"],\n",
-    "        reservation_id=lease.get_device_reservation(lease_id),\n",
-    "        platform_version=2,\n",
-    "    )\n",
-    "except RuntimeError as ex:\n",
-    "    print(ex)\n",
-    "    print(f\"please stop and/or delete {container_name} and try again\")\n",
-    "else:\n",
-    "    print(f\"Successfully created container: {container_name}!\")"
+    "First, lets run a simple command to see if libcamera finds our camera. If the container started with the pi_libcamera device profile, this *should* work, but there are always some edge cases.\n",
+    "This will also help identify the capabilities of the attached camera.\n",
+    "\n",
+    "Note: We specify `--nopreview` since there's no display attached to the device."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28aba244",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmd = \"rpicam-hello --nopreview --list-cameras\"\n",
+    "result,code = my_container.execute(cmd)\n",
+    "print(result)"
    ]
   },
   {
@@ -156,8 +163,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cmd = \"rpicam-still -o image.png --width 1920 --height 1080\"\n",
-    "print(chi.container.execute(my_container.uuid, cmd)[\"output\"])"
+    "cmd = \"rpicam-still  --nopreview  --output /app/test1.png --width 1920 --height 1080\"\n",
+    "result,code = my_container.execute(cmd)\n",
+    "print(result)"
    ]
   },
   {
@@ -170,12 +178,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "id": "f446130b-ab84-4542-9759-6495c6d1e40d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "chi.container.download(my_container.uuid, \"/home/image.png\",\".\")"
+    "my_container.download(\"/app/test1.png\", \".\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8e7b1f1",
+   "metadata": {},
+   "source": [
+    "## Using the picamera2 library instead of cli\n",
+    "\n",
+    "Now, insted of running the command interactively, we'll instead use the picamera2 library to do the same task. \n",
+    "\n",
+    "The snippet below will copy a script into the container, execute it, then copy the captured image image back."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cad98b7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Need to get the path for the python script in jupyter\n",
+    "import os\n",
+    "cwd = os.getcwd()\n",
+    "my_container.upload(f\"{cwd}/camera_test.py\", \"/app/\")\n",
+    "\n",
+    "# execute it\n",
+    "result,code = my_container.execute(\"python3 camera_test.py\")\n",
+    "print(result)\n",
+    "\n",
+    "# copy the output image back\n",
+    "my_container.download(\"/app/test2.jpg\", \".\")"
    ]
   },
   {
@@ -185,7 +225,9 @@
    "source": [
     "## Capturing a 5 second 1080p 60fps H264 video with the camera\n",
     "\n",
-    "To capture an h264 video we use the ```rpicam-vid```[(docs)](https://www.raspberrypi.com/documentation/computers/camera_software.html#rpicam-vid) utility to capture a 5 second 1080p video at a framerate of 60 fps. To playback the video, please download the file through the jupyter interface and use a video playback utility such as ```vlc```."
+    "To capture an h264 video we use the ```rpicam-vid```[(docs)](https://www.raspberrypi.com/documentation/computers/camera_software.html#rpicam-vid) utility to capture a 5 second 1080p video at a framerate of 60 fps. To playback the video, please download the file through the jupyter interface and use a video playback utility such as ```vlc```.\n",
+    "\n",
+    "**Note**: the ```container.download()``` utility is primarily meant for smaller size files. Please resort to other methods such as cloud storage or scp to download larger files."
    ]
   },
   {
@@ -195,26 +237,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cmd = \"rpicam-vid -t 5000 --framerate 60 --width 1920 --height 1080 -o video.h264\"\n",
-    "print(chi.container.execute(my_container.uuid, cmd)[\"output\"])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "858ab551-8109-4415-9cb3-2209e7dc6602",
-   "metadata": {},
-   "source": [
-    "**Important note**: the ```container.download()``` utility is primarily meant for smaller size files. Please resort to other methods such as cloud storage or scp to download larger files."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 38,
-   "id": "f08334e4-e3ef-4f1f-ac11-320db998a8fe",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "chi.container.download(my_container.uuid, \"/home/video.h264\",\".\")"
+    "cmd = \"rpicam-vid --nopreview  --output /app/video1.h264 --width 1920 --height 1080 --framerate 60\"\n",
+    "result,code = my_container.execute(cmd)\n",
+    "print(result)\n",
+    "\n",
+    "my_container.download(\"/app/video1.h264\", \".\")"
    ]
   }
  ],

--- a/picamera_tutorial.ipynb
+++ b/picamera_tutorial.ipynb
@@ -18,7 +18,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ad4bcf2d-b458-4436-95ab-4cd99e6321f0",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from chi import context\n",
@@ -41,7 +43,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5d19779e-e688-45e0-90f0-8b336411ec4a",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from chi import hardware\n",
@@ -65,7 +69,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3adb24c1",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from chi import lease\n",
@@ -73,7 +79,7 @@
     "\n",
     "my_lease = lease.Lease(\"rpi4-camera-lease\", duration=timedelta(hours=3))\n",
     "\n",
-    "my_lease.add_device_reservation(picamera_devs[0])\n",
+    "my_lease.add_device_reservation(devices=[picamera_devs[0]])  # we're just getting a list of 1 device\n",
     "# my_lease.add_device_reservation(device_name='iot-rpi4-picam2',amount=1) # or a specific one!\n",
     "my_lease.submit(idempotent=True)"
    ]
@@ -100,17 +106,19 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "77feeef9-9f69-440e-a1b9-d392d9b5db33",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from chi import container\n",
     "\n",
     "my_container = container.Container(\n",
     "    \"rpi4-camera-test-01\",\n",
-    "    image_ref=\"shermanm/picamera:latest\",\n",
+    "    image_ref=\"ghcr.io/chameleoncloud/edge-picamera-image:latest\",\n",
     "    exposed_ports=[],\n",
     "    reservation_id=my_lease.device_reservations[0][\"id\"],\n",
-    "    command=[\"sleep\", \"3600\"],\n",
+    "    command=[\"sleep\", \"infinity\"],\n",
     "    device_profiles=[\"pi_libcamera\"],\n",
     ")\n",
     "my_container.submit()"
@@ -133,7 +141,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "28aba244",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "cmd = \"rpicam-hello --nopreview --list-cameras\"\n",
@@ -160,7 +170,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "28caaf2e-afc2-497a-b1f4-795c6a84b2c7",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "cmd = \"rpicam-still  --nopreview  --output /app/test1.png --width 1920 --height 1080\"\n",
@@ -180,10 +192,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f446130b-ab84-4542-9759-6495c6d1e40d",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "my_container.download(\"/app/test1.png\", \".\")"
+    "my_container.download(\"/app/test1.png\", \".\")\n",
+    "from IPython.display import Image\n",
+    "Image(\"test1.png\", height=640,width=480)"
    ]
   },
   {
@@ -202,7 +218,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cad98b7f",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Need to get the path for the python script in jupyter\n",
@@ -212,10 +230,22 @@
     "\n",
     "# execute it\n",
     "result,code = my_container.execute(\"python3 camera_test.py\")\n",
-    "print(result)\n",
-    "\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1ec4c91-a3a8-4d0d-ad51-489488065b42",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
     "# copy the output image back\n",
-    "my_container.download(\"/app/test2.jpg\", \".\")"
+    "my_container.download(\"/app/test2.png\", \".\")\n",
+    "from IPython.display import Image\n",
+    "Image(\"test2.png\", height=640,width=480)"
    ]
   },
   {
@@ -223,9 +253,9 @@
    "id": "c0786f1e-f5cf-43d6-bb23-120c910974eb",
    "metadata": {},
    "source": [
-    "## Capturing a 5 second 1080p 60fps H264 video with the camera\n",
+    "## Capturing a 5 second 1080p 30fps H264 video with the camera\n",
     "\n",
-    "To capture an h264 video we use the ```rpicam-vid```[(docs)](https://www.raspberrypi.com/documentation/computers/camera_software.html#rpicam-vid) utility to capture a 5 second 1080p video at a framerate of 60 fps. To playback the video, please download the file through the jupyter interface and use a video playback utility such as ```vlc```.\n",
+    "To capture an h264 video we use the ```rpicam-vid```[(docs)](https://www.raspberrypi.com/documentation/computers/camera_software.html#rpicam-vid) utility to capture a 5 second 1080p video at a framerate of 30 fps. To playback the video, please download the file through the jupyter interface and use a video playback utility such as ```vlc```.\n",
     "\n",
     "**Note**: the ```container.download()``` utility is primarily meant for smaller size files. Please resort to other methods such as cloud storage or scp to download larger files."
    ]
@@ -234,14 +264,55 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bb9c1495-734d-4023-9147-61a65b83b148",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cmd = \"rpicam-vid --nopreview -t 5000 --output /app/video1.mp4 --width 1920 --height 1080 --framerate 24\"\n",
+    "result,code = my_container.execute(cmd)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db003019-2f2d-4ea6-af23-1f7580800c80",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# and copy it back\n",
+    "my_container.download(\"/app/video1.h264\", \".\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58cf04d9",
+   "metadata": {},
+   "source": [
+    "## Cleanup :)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0d72918",
    "metadata": {},
    "outputs": [],
    "source": [
-    "cmd = \"rpicam-vid --nopreview  --output /app/video1.h264 --width 1920 --height 1080 --framerate 60\"\n",
-    "result,code = my_container.execute(cmd)\n",
-    "print(result)\n",
-    "\n",
-    "my_container.download(\"/app/video1.h264\", \".\")"
+    "my_container.delete()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3f88ebc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_lease.delete()"
    ]
   }
  ],
@@ -261,7 +332,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Update to use in-tree dependencies for libcamera and picamera2 from raspberry pi apt repos, this avoids needing to compile it manually.

Additionally use moden python-chi approach, and add an example for use of picamera2 python library.